### PR TITLE
Transparent App Icon Background for Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,8 +9,8 @@
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher"
-      android:roundIcon="@mipmap/ic_launcher_round"
+      android:icon="@mipmap/ic_launcher_foreground"
+      android:roundIcon="@mipmap/ic_launcher_foreground"
       android:allowBackup="false"
       android:usesCleartextTraffic="true"
       android:theme="@style/AppTheme">


### PR DESCRIPTION
Changed the used icon and roundIcon for the Android App to the transparent foreground version of the icon