### PR TITLE
News aktualisieren nach 1 Stunde

### DIFF
--- a/js/tabs/news/NewsScreen.js
+++ b/js/tabs/news/NewsScreen.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -6,7 +6,7 @@ import {
   StyleSheet,
   View
 } from 'react-native';
-import { useNavigation } from 'react-navigation-hooks';
+import {useFocusEffect, useNavigation} from 'react-navigation-hooks';
 
 import { format } from 'date-fns';
 import { de } from 'date-fns/locale';
@@ -108,6 +108,8 @@ function getPages(news, isLoading, refresh, navigate) {
   });
 }
 
+let lastDataFetch = 0;
+
 export default function NewsScreen() {
   const [isLoading, setLoading] = useState(true);
   const [hasNetworkError, setNetworkError] = useState(false);
@@ -123,15 +125,27 @@ export default function NewsScreen() {
       setNetworkError(true);
     } else {
       saveNewsToStore(data);
+      lastDataFetch = new Date().getTime();
       setNews(data);
     }
     setLoading(false);
   }
 
+  useFocusEffect(
+      useCallback(() => {
+        if (new Date().getTime() > lastDataFetch + 1000*60*60 ) {
+          setLoading(true);
+          loadData();
+        }
+      }, [])
+  );
+
   // load data from local store or from web if store is emtpy
   async function loadData() {
     let data = await loadNewsFromStore();
     if (data !== null) {
+      console.log("Loading data");
+      lastDataFetch = new Date().getTime();
       setNews(data);
       setLoading(false);
     } else refresh();

--- a/js/tabs/news/store.js
+++ b/js/tabs/news/store.js
@@ -5,11 +5,32 @@ import { feeds } from '../../util/Constants';
 
 export async function loadNewsFromStore() {
   const data = await AsyncStorage.getItem('news');
-  return JSON.parse(data);
+
+  if (data == null) {
+      return null;
+  }
+
+  const parsedData = JSON.parse(data);
+
+  //Backwards compatibility
+  if (!("lastfetch" in parsedData)) {
+      return null;
+  }
+
+  //Deliver no data if older than 60 minutes
+  if (new Date().getTime() > parsedData.lastfetch + 60*60*1000) {
+      return null;
+  }
+  console.log("Loading news from fileSystem");
+  return parsedData.news;
 }
 
-export function saveNewsToStore(data) {
-  AsyncStorage.setItem('news', JSON.stringify(data));
+export function saveNewsToStore(news) {
+    const dataToSave = {
+        lastfetch: new Date().getTime(),
+        news
+    };
+    AsyncStorage.setItem('news', JSON.stringify(dataToSave));
 }
 
 export async function fetchNewsFromWeb() {


### PR DESCRIPTION
News werden nur noch aus dem Gerätespeicher geladen wenn diese maximal 1 Stunde alt sind. Somit wird vermieden das veraltete Nachrichten geladen werden.